### PR TITLE
Add metrics instrumentation to NagiosHandler and GangliaHandler

### DIFF
--- a/src/main/kotlin/com/groupon/aint/kmond/metrics/AintMetricsFactory.kt
+++ b/src/main/kotlin/com/groupon/aint/kmond/metrics/AintMetricsFactory.kt
@@ -24,7 +24,6 @@ import io.vertx.core.spi.VertxMetricsFactory
 import io.vertx.core.spi.metrics.VertxMetrics
 import java.io.File
 import java.util.ArrayList
-import kotlin.concurrent.timer
 
 /**
  * Implementation of VertxMetricsFactory using AintMetricsFactory.
@@ -55,11 +54,13 @@ class AintMetricsFactory : VertxMetricsFactory {
         }
 
 
-        val metricsAdapter = AintMetricsAdapter(TsdMetricsFactory.Builder()
+        val metricsFactory = TsdMetricsFactory.Builder()
                 .setSinks(sinkList)
                 .setClusterName(aintMetricsOptions.clusterName)
                 .setServiceName(aintMetricsOptions.serviceName)
-                .build())
+                .build()
+        AintMetricsFactoryWrapper.initialize(metricsFactory)
+        val metricsAdapter = AintMetricsAdapter(metricsFactory)
 
 
         metricsAdapter.start()

--- a/src/main/kotlin/com/groupon/aint/kmond/metrics/AintMetricsFactoryWrapper.kt
+++ b/src/main/kotlin/com/groupon/aint/kmond/metrics/AintMetricsFactoryWrapper.kt
@@ -1,0 +1,20 @@
+package com.groupon.aint.kmond.metrics
+
+import com.arpnetworking.metrics.MetricsFactory
+
+/**
+ * A static holder for AintMetrics to serve the same factory to vertx and the rest of the application.
+ *
+ * @author Matthew Hayter (mhayter at groupon dot com)
+ */
+object AintMetricsFactoryWrapper {
+    private var metricsFactory: MetricsFactory? = null
+
+    fun initialize(tsdMetricsFactory: MetricsFactory) {
+        metricsFactory = tsdMetricsFactory
+    }
+
+    fun getMetricsFactory(): MetricsFactory? {
+        return metricsFactory
+    }
+}

--- a/src/main/kotlin/com/groupon/aint/kmond/output/GangliaHandler.kt
+++ b/src/main/kotlin/com/groupon/aint/kmond/output/GangliaHandler.kt
@@ -87,7 +87,8 @@ class GangliaHandler(val vertx: Vertx, val appMetricsFactory: MetricsFactory) : 
                     }
                 }
 
-                appMetrics.setGauge(APP_METRICS_PREFIX + "/bytes_sent", packetSizeSum)
+                appMetrics.resetCounter(APP_METRICS_PREFIX + "/bytes_sent")
+                appMetrics.incrementCounter(APP_METRICS_PREFIX + "/bytes_sent", packetSizeSum)
 
                 after().thenSync({
                     closeMetrics(appMetrics, requestTimer, true)
@@ -213,16 +214,11 @@ class GangliaHandler(val vertx: Vertx, val appMetricsFactory: MetricsFactory) : 
     }
 
     private fun addSuccessMetric(metrics: com.arpnetworking.metrics.Metrics, success: Boolean) {
-        var successGauge: Long
-        var failGauge: Long
+        var successGauge: Long = 0
         if (success) {
             successGauge = 1
-            failGauge = 0
-        } else {
-            successGauge = 0
-            failGauge = 1
         }
-        metrics.setGauge(APP_METRICS_PREFIX + "/success", successGauge)
-        metrics.setGauge(APP_METRICS_PREFIX + "/failure", failGauge)
+        metrics.resetCounter(APP_METRICS_PREFIX + "/success")
+        metrics.incrementCounter(APP_METRICS_PREFIX + "/success", successGauge)
     }
 }

--- a/src/main/kotlin/com/groupon/aint/kmond/output/GangliaHandler.kt
+++ b/src/main/kotlin/com/groupon/aint/kmond/output/GangliaHandler.kt
@@ -77,11 +77,8 @@ class GangliaHandler(val vertx: Vertx, val appMetricsFactory: MetricsFactory) : 
                         packetSizeSum += packet.first.length() + packet.second.length()
 
                         async(SendDatagramPacket(packet.first, host, port)) {
-                            async(SendDatagramPacket(packet.second, host, port)) {
-                                thenSync({}, {
-                                    requestTimer.stop()
-                                })
-                            }
+                            thenAsync(SendDatagramPacket(packet.second, host, port))
+
                             after().thenSync({}, {
                                 log.warn("send", "failure", arrayOf("gangliaPort", "gangliaHost", "metricsCluster"),
                                         port, host, metrics.cluster, it)

--- a/src/main/kotlin/com/groupon/aint/kmond/output/GangliaHandler.kt
+++ b/src/main/kotlin/com/groupon/aint/kmond/output/GangliaHandler.kt
@@ -67,6 +67,7 @@ class GangliaHandler(val vertx: Vertx, val appMetricsFactory: MetricsFactory) : 
         val packets = createXdrs(metrics)
 
         val appMetrics = appMetricsFactory.create()
+        appMetrics.resetCounter(APP_METRICS_PREFIX + "/unknown_cluster")
 
         if (port != null && hosts.size > 0) {
             val requestTimer = appMetrics.createTimer(APP_METRICS_PREFIX + "/request")
@@ -100,7 +101,7 @@ class GangliaHandler(val vertx: Vertx, val appMetricsFactory: MetricsFactory) : 
             }
         } else {
             log.warn("send", "unknownCluster", arrayOf("cluster"), metrics.cluster)
-            addSuccessMetric(appMetrics, false)
+            appMetrics.incrementCounter(APP_METRICS_PREFIX + "/unknown_cluster")
             appMetrics.close()
         }
     }

--- a/src/main/kotlin/com/groupon/aint/kmond/output/NagiosHandler.kt
+++ b/src/main/kotlin/com/groupon/aint/kmond/output/NagiosHandler.kt
@@ -33,8 +33,7 @@ import java.util.concurrent.TimeUnit
 /**
  * Output handler for sending events to Nagios.
  *
- * @param appMetricsFactory Used to create metrics with respect to KMonD, e.g. using the AINT Metrics platform;
- * unrelated to the metrics being forwarded to Nagios.
+ * @param appMetricsFactory Used to create metrics that instrument KMonD itself; unrelated to the metrics being forwarded to Nagios.
  *
  * @author fsiegrist (fsiegrist at groupon dot com)
  */

--- a/src/main/kotlin/com/groupon/aint/kmond/output/NagiosHandler.kt
+++ b/src/main/kotlin/com/groupon/aint/kmond/output/NagiosHandler.kt
@@ -60,7 +60,6 @@ class NagiosHandler(val vertx: Vertx, val appMetricsFactory: MetricsFactory, val
         val nagiosHost = getNagiosHost(clusterId, metrics.host) ?: return
         val httpClient = httpClientsMap[nagiosHost] ?: createHttpClient(nagiosHost)
 
-        // Metrics factory should never return null: unchecked null
         val appMetrics: com.arpnetworking.metrics.Metrics = appMetricsFactory.create()
         appMetrics.setGauge(APP_METRICS_PREFIX + "/metrics_count", metrics.metrics.size.toLong())
         val timer = appMetrics.createTimer(APP_METRICS_PREFIX + "/request")

--- a/src/main/kotlin/com/groupon/aint/kmond/output/NagiosHandler.kt
+++ b/src/main/kotlin/com/groupon/aint/kmond/output/NagiosHandler.kt
@@ -61,7 +61,8 @@ class NagiosHandler(val vertx: Vertx, val appMetricsFactory: MetricsFactory, val
         val httpClient = httpClientsMap[nagiosHost] ?: createHttpClient(nagiosHost)
 
         val appMetrics: com.arpnetworking.metrics.Metrics = appMetricsFactory.create()
-        appMetrics.setGauge(APP_METRICS_PREFIX + "/metrics_count", metrics.metrics.size.toLong())
+        appMetrics.resetCounter(APP_METRICS_PREFIX + "/metrics_count")
+        appMetrics.incrementCounter(APP_METRICS_PREFIX + "/metrics_count", metrics.metrics.size.toLong())
         val timer = appMetrics.createTimer(APP_METRICS_PREFIX + "/request")
 
         val httpRequest = httpClient.request(HttpMethod.POST, "/nagios/cmd.php", {

--- a/src/main/kotlin/com/groupon/aint/kmond/output/NagiosHandler.kt
+++ b/src/main/kotlin/com/groupon/aint/kmond/output/NagiosHandler.kt
@@ -169,10 +169,10 @@ class NagiosHandler(val vertx: Vertx, val appMetricsFactory: MetricsFactory, val
         var countOther: Long = 0
 
         when (statusCode) {
-            in 200..299 -> count2xx += 1
-            in 400..499 -> count4xx += 1
-            in 500..599 -> count5xx += 1
-            else -> countOther += 1
+            in 200..299 -> count2xx = 1
+            in 400..499 -> count4xx = 1
+            in 500..599 -> count5xx = 1
+            else -> countOther = 1
         }
 
         metric.incrementCounter(APP_METRICS_PREFIX + "/status/2xx", count2xx)

--- a/src/main/kotlin/com/groupon/aint/kmond/output/NagiosHandler.kt
+++ b/src/main/kotlin/com/groupon/aint/kmond/output/NagiosHandler.kt
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit
  */
 class NagiosHandler(val vertx: Vertx, val appMetricsFactory: MetricsFactory, val clusterId: String, val httpClientConfig: JsonObject = JsonObject()): Handler<Message<Metrics>> {
     private val httpClientsMap = HashMap<String, HttpClient>()
+    private val APP_METRICS_PREFIX = "downstream/nagios"
 
     companion object {
         private val log = Logger.getLogger(NagiosHandler::class.java)
@@ -62,7 +63,8 @@ class NagiosHandler(val vertx: Vertx, val appMetricsFactory: MetricsFactory, val
 
         // Metrics factory should never return null: unchecked null
         val appMetrics: com.arpnetworking.metrics.Metrics = appMetricsFactory.create()
-        val timer = appMetrics.createTimer("kmond/nagios/request")
+        appMetrics.setGauge(APP_METRICS_PREFIX + "/metrics_count", metrics.metrics.size.toLong())
+        val timer = appMetrics.createTimer(APP_METRICS_PREFIX + "/request")
 
         val httpRequest = httpClient.request(HttpMethod.POST, "/nagios/cmd.php", {
             timer.stop()
@@ -174,9 +176,9 @@ class NagiosHandler(val vertx: Vertx, val appMetricsFactory: MetricsFactory, val
             else -> countOther += 1
         }
 
-        metric.incrementCounter("kmond/nagios/status/2xx", count2xx)
-        metric.incrementCounter("kmond/nagios/status/4xx", count4xx)
-        metric.incrementCounter("kmond/nagios/status/5xx", count5xx)
-        metric.incrementCounter("kmond/nagios/status/other", countOther)
+        metric.incrementCounter(APP_METRICS_PREFIX + "/status/2xx", count2xx)
+        metric.incrementCounter(APP_METRICS_PREFIX + "/status/4xx", count4xx)
+        metric.incrementCounter(APP_METRICS_PREFIX + "/status/5xx", count5xx)
+        metric.incrementCounter(APP_METRICS_PREFIX + "/status/other", countOther)
     }
 }

--- a/src/test/kotlin/com/groupon/aint/kmond/KMonDVerticleTest.kt
+++ b/src/test/kotlin/com/groupon/aint/kmond/KMonDVerticleTest.kt
@@ -15,8 +15,10 @@
  */
 package com.groupon.aint.kmond
 
+import com.arpnetworking.metrics.MetricsFactory
 import com.groupon.aint.kmond.config.mock
 import com.groupon.aint.kmond.eventbus.V1ResultCodec
+import com.groupon.aint.kmond.metrics.AintMetricsFactoryWrapper
 import io.vertx.core.Context
 import io.vertx.core.Future
 import io.vertx.core.Vertx
@@ -46,6 +48,7 @@ class KMonDVerticleTest {
     private val metricsConsumer = mock<MessageConsumer<Metrics>>()
     private val metricsProducer = mock<MessageProducer<Metrics>>()
     private val stringProducer = mock<MessageProducer<String>>()
+    private val metricsFactory = mock<MetricsFactory>()
 
     private var kmondConfig = JsonObject()
 
@@ -67,6 +70,8 @@ class KMonDVerticleTest {
     fun startTest() {
         val kmondVerticle = KMonDVerticle()
         kmondVerticle.init(vertx, context)
+
+        AintMetricsFactoryWrapper.initialize(metricsFactory)
 
         val result = Future.future<Void>();
         kmondVerticle.start(result)

--- a/src/test/kotlin/com/groupon/aint/kmond/output/GangliaHandlerTest.kt
+++ b/src/test/kotlin/com/groupon/aint/kmond/output/GangliaHandlerTest.kt
@@ -15,6 +15,9 @@
  */
 package com.groupon.aint.kmond.output
 
+import com.arpnetworking.metrics.MetricsFactory
+import com.arpnetworking.metrics.Sink
+import com.arpnetworking.metrics.impl.TsdMetricsFactory
 import com.groupon.aint.kmond.config.mock
 import com.groupon.aint.kmond.input.V1Result
 import io.vertx.core.Vertx
@@ -22,6 +25,7 @@ import io.vertx.core.datagram.DatagramSocket
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
+import java.util.Arrays
 import java.util.HashMap
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
@@ -37,7 +41,13 @@ class GangliaHandlerTest {
     private val vertx = mock<Vertx>()
     private val datagramSocket = mock<DatagramSocket>()
     private val metricsMap = HashMap<String, Float>()
-    private val metricsFactory = mock<com.arpnetworking.metrics.MetricsFactory>()
+    private val sink = mock<Sink>()
+    private var metricsFactory: MetricsFactory = TsdMetricsFactory.Builder()
+            .setClusterName("someCluster")
+            .setHostName("someHost")
+            .setServiceName("someService")
+            .setSinks(Arrays.asList(sink))
+            .build()
 
     @Before
     fun setUp() {

--- a/src/test/kotlin/com/groupon/aint/kmond/output/GangliaHandlerTest.kt
+++ b/src/test/kotlin/com/groupon/aint/kmond/output/GangliaHandlerTest.kt
@@ -37,6 +37,7 @@ class GangliaHandlerTest {
     private val vertx = mock<Vertx>()
     private val datagramSocket = mock<DatagramSocket>()
     private val metricsMap = HashMap<String, Float>()
+    private val metricsFactory = mock<com.arpnetworking.metrics.MetricsFactory>()
 
     @Before
     fun setUp() {
@@ -45,28 +46,28 @@ class GangliaHandlerTest {
 
     @Test
     fun isNotLaggingTest() {
-        val gangliaHandler = GangliaHandler(vertx)
+        val gangliaHandler = GangliaHandler(vertx, metricsFactory)
         assertFalse(gangliaHandler.isLagging(V1Result("path", "monitor", 0, "output", 1,
                 TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS), "host", "cluster", false, metricsMap)))
     }
 
     @Test
     fun isLaggingTest() {
-        val gangliaHandler = GangliaHandler(vertx)
+        val gangliaHandler = GangliaHandler(vertx, metricsFactory)
         assertTrue(gangliaHandler.isLagging(V1Result("path", "monitor", 0, "output", 1,
                 TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS) - 3700, "host", "cluster", false, metricsMap)))
     }
 
     @Test
     fun statusValueNotLaggingTest() {
-        val gangliaHandler = GangliaHandler(vertx)
+        val gangliaHandler = GangliaHandler(vertx, metricsFactory)
         assertEquals(0, gangliaHandler.statusValue(V1Result("path", "monitor", 0, "output", 1,
                 TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS), "host", "cluster", false, metricsMap)))
     }
 
     @Test
     fun statusValueLaggingTest() {
-        val gangliaHandler = GangliaHandler(vertx)
+        val gangliaHandler = GangliaHandler(vertx, metricsFactory)
         assertEquals(4, gangliaHandler.statusValue(V1Result("path", "monitor", 0, "output", 1,
                 TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS) - 3700, "host", "cluster", false, metricsMap)))
     }

--- a/src/test/kotlin/com/groupon/aint/kmond/output/NagiosHandlerTest.kt
+++ b/src/test/kotlin/com/groupon/aint/kmond/output/NagiosHandlerTest.kt
@@ -119,9 +119,8 @@ class NagiosHandlerTest {
 
         Mockito.verify(sink, Mockito.times(1)).record(appMetricsEventCaptor.capture())
 
-        val gaugeSamples = appMetricsEventCaptor.value.gaugeSamples
-        assertEquals(1, gaugeSamples.get("downstream/nagios/metrics_count")?.get(0)?.value?.toInt())
         val counterSamples = appMetricsEventCaptor.value.counterSamples
+        assertEquals(1, counterSamples.get("downstream/nagios/metrics_count")?.get(0)?.value?.toInt())
         assertEquals(1, counterSamples.get("downstream/nagios/status/2xx")?.get(0)?.value?.toInt())
         assertEquals(0, counterSamples.get("downstream/nagios/status/4xx")?.get(0)?.value?.toInt())
         assertEquals(0, counterSamples.get("downstream/nagios/status/5xx")?.get(0)?.value?.toInt())

--- a/src/test/kotlin/com/groupon/aint/kmond/output/NagiosHandlerTest.kt
+++ b/src/test/kotlin/com/groupon/aint/kmond/output/NagiosHandlerTest.kt
@@ -107,7 +107,7 @@ class NagiosHandlerTest {
     }
 
     @Test
-    fun testhasAlertsMetricsTest() {
+    fun hasAlertsMetricsTest() {
         val nagiosHandler = NagiosHandler(vertx, metricsFactory, "clusterId", JsonObject())
         metricsMap.put("mean_critical", 1F)
         clusterMap.put("clusterId", mapOf(Pair("nagiosHost", (0..99).toList())))
@@ -128,10 +128,6 @@ class NagiosHandlerTest {
         assertEquals(0, counterSamples.get("downstream/nagios/status/5xx")?.get(0)?.value)
         val timerSamples = appMetricsEventCaptor.value.timerSamples
         assertEquals(1, timerSamples.get("downstream/nagios/request")?.size)
-
-
-
-
     }
 
     @Test


### PR DESCRIPTION
* The AINT metrics factory is now shared with vert.x and the global state via the kotlin `object` `AintMetricsFactoryWrapper`

Addresses  #14 